### PR TITLE
🌱 remove goconst and goimports

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -70,14 +70,14 @@ jobs:
       #     GIT_ACCESS_TOKEN: ${{ secrets.GIT_ACCESS_TOKEN }}
       #   run: make test-integration
 
-        # - name: Test Summary
-        #   uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f # v2.1
-        #   with:
-        #     paths: ".coverage/junit.xml"
+      # - name: Test Summary
+      #   uses: test-summary/action@62bc5c68de2a6a0d02039763b8c754569df99e3f # v2.1
+      #   with:
+      #     paths: ".coverage/junit.xml"
 
-        # - name: Upload Report
-        #   uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
-        #   with:
-        #     name: reports-${{ steps.name.outputs.name }}
-        #     path: .reports
-        #     retention-days: 30
+      # - name: Upload Report
+      #   uses: actions/upload-artifact@0b7f8abb1508181956e8e162db84b466c27e18ce # v3.1.2
+      #   with:
+      #     name: reports-${{ steps.name.outputs.name }}
+      #     path: .reports
+      #     retention-days: 30

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,12 +15,12 @@ linters:
     - exportloopref
     - forcetypeassert
     - gci
-    - goconst
+    # - goconst
     - gocritic
     - godot
     - gofmt
     - gofumpt
-    - goimports
+    # - goimports
     - goprintffuncname
     - gosec
     - gosimple
@@ -104,6 +104,10 @@ linters-settings:
   revive:
     enable-all-rules: true
     rules:
+      - name: import-alias-naming
+        disabled: true
+      - name: redundant-import-alias
+        disabled: true
       - name: dot-imports
         disabled: true
       # https://github.com/mgechev/revive/blob/master/RULES_DESCRIPTIONS.md#add-constant

--- a/Makefile
+++ b/Makefile
@@ -347,7 +347,6 @@ else
 	go version
 	golangci-lint version
 	golangci-lint run -v
-	cd $(TEST_DIR); golangci-lint run -v
 endif
 
 .PHONY: lint-golang-ci
@@ -361,7 +360,6 @@ else
 	go version
 	golangci-lint version
 	golangci-lint run -v --out-format=github-actions
-	cd $(TEST_DIR); golangci-lint run -v --out-format=github-actions
 endif
 
 .PHONY: lint-yaml

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -26,7 +26,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime"
 	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
 	_ "k8s.io/client-go/plugin/pkg/client/auth"

--- a/hack/version.sh
+++ b/hack/version.sh
@@ -64,7 +64,7 @@ version::get_version_vars() {
         fi
     fi
 
-    GIT_RELEASE_TAG=$(git describe --abbrev=0 --tags)
+    GIT_RELEASE_TAG=$(git describe --abbrev=0 --tags 2>/dev/null)
 }
 
 # borrowed from k8s.io/hack/lib/version.sh and modified

--- a/internal/controller/openstackclusterstackrelease_controller.go
+++ b/internal/controller/openstackclusterstackrelease_controller.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"context"
 
-	infrastructureclusterstackxk8siov1alpha1 "github.com/sovereignCloudStack/cluster-stack-provider-openstack/api/v1alpha1"
+	infrav1alpha1 "github.com/sovereignCloudStack/cluster-stack-provider-openstack/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,6 +48,9 @@ type OpenstackClusterStackReleaseReconciler struct {
 func (r *OpenstackClusterStackReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
+	openstackclusterstackrelease := &infrav1alpha1.OpenstackClusterStackRelease{}
+	_ = r.Client.Get(ctx, req.NamespacedName, openstackclusterstackrelease)
+
 	// TODO(user): your logic here
 
 	return ctrl.Result{}, nil
@@ -56,6 +59,6 @@ func (r *OpenstackClusterStackReleaseReconciler) Reconcile(ctx context.Context, 
 // SetupWithManager sets up the controller with the Manager.
 func (r *OpenstackClusterStackReleaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&infrastructureclusterstackxk8siov1alpha1.OpenstackClusterStackRelease{}).
+		For(&infrav1alpha1.OpenstackClusterStackRelease{}).
 		Complete(r)
 }

--- a/internal/controller/openstackclusterstackreleasetemplate_controller.go
+++ b/internal/controller/openstackclusterstackreleasetemplate_controller.go
@@ -19,7 +19,7 @@ package controller
 import (
 	"context"
 
-	infrastructureclusterstackxk8siov1alpha1 "github.com/sovereignCloudStack/cluster-stack-provider-openstack/api/v1alpha1"
+	infrav1alpha1 "github.com/sovereignCloudStack/cluster-stack-provider-openstack/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -48,7 +48,8 @@ type OpenstackClusterStackReleaseTemplateReconciler struct {
 func (r *OpenstackClusterStackReleaseTemplateReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
-	// TODO(user): your logic here
+	openstackclusterstackreleasetemplate := &infrav1alpha1.OpenstackClusterStackReleaseTemplate{}
+	_ = r.Client.Get(ctx, req.NamespacedName, openstackclusterstackreleasetemplate)
 
 	return ctrl.Result{}, nil
 }
@@ -56,6 +57,6 @@ func (r *OpenstackClusterStackReleaseTemplateReconciler) Reconcile(ctx context.C
 // SetupWithManager sets up the controller with the Manager.
 func (r *OpenstackClusterStackReleaseTemplateReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&infrastructureclusterstackxk8siov1alpha1.OpenstackClusterStackReleaseTemplate{}).
+		For(&infrav1alpha1.OpenstackClusterStackReleaseTemplate{}).
 		Complete(r)
 }

--- a/internal/controller/openstacknodeimagerelease_controller.go
+++ b/internal/controller/openstacknodeimagerelease_controller.go
@@ -20,7 +20,7 @@ package controller
 import (
 	"context"
 
-	infrastructureclusterstackxk8siov1alpha1 "github.com/sovereignCloudStack/cluster-stack-provider-openstack/api/v1alpha1"
+	infrav1alpha1 "github.com/sovereignCloudStack/cluster-stack-provider-openstack/api/v1alpha1"
 	"k8s.io/apimachinery/pkg/runtime"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -49,7 +49,8 @@ type OpenstackNodeImageReleaseReconciler struct {
 func (r *OpenstackNodeImageReleaseReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	_ = log.FromContext(ctx)
 
-	// TODO(user): your logic here
+	openstacknodeimagerelease := infrav1alpha1.OpenstackNodeImageRelease{}
+	_ = r.Client.Get(ctx, req.NamespacedName, &openstacknodeimagerelease)
 
 	return ctrl.Result{}, nil
 }
@@ -57,6 +58,6 @@ func (r *OpenstackNodeImageReleaseReconciler) Reconcile(ctx context.Context, req
 // SetupWithManager sets up the controller with the Manager.
 func (r *OpenstackNodeImageReleaseReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&infrastructureclusterstackxk8siov1alpha1.OpenstackNodeImageRelease{}).
+		For(&infrav1alpha1.OpenstackNodeImageRelease{}).
 		Complete(r)
 }


### PR DESCRIPTION
remove goconst and goimports from golangci config. This also adds revive
latest config.

Signed-off-by: Anurag <anurag.kumar@syself.com>
