### PR TITLE
:sparkles: Add AGE column for openstackclusterstackrelease

### DIFF
--- a/api/v1alpha1/openstackclusterstackrelease_types.go
+++ b/api/v1alpha1/openstackclusterstackrelease_types.go
@@ -42,6 +42,7 @@ type OpenStackClusterStackReleaseStatus struct {
 //+kubebuilder:object:root=true
 //+kubebuilder:subresource:status
 //+kubebuilder:printcolumn:name="Ready",type="boolean",JSONPath=".status.ready"
+//+kubebuilder:printcolumn:name="Age",type="date",JSONPath=".metadata.creationTimestamp",description="Time duration since creation of OpenStackClusterStackRelease"
 
 // OpenStackClusterStackRelease is the Schema for the openstackclusterstackreleases API.
 type OpenStackClusterStackRelease struct {

--- a/config/crd/bases/infrastructure.clusterstack.x-k8s.io_openstackclusterstackreleases.yaml
+++ b/config/crd/bases/infrastructure.clusterstack.x-k8s.io_openstackclusterstackreleases.yaml
@@ -18,6 +18,10 @@ spec:
     - jsonPath: .status.ready
       name: Ready
       type: boolean
+    - description: Time duration since creation of OpenStackClusterStackRelease
+      jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
     name: v1alpha1
     schema:
       openAPIV3Schema:


### PR DESCRIPTION
**What this PR does / why we need it**:

It was removed when the *Ready* field was introduced