### PR TITLE
🐛  update to v2 release of openstack-scs clusterstack

### DIFF
--- a/config/cspo/cluster.yaml
+++ b/config/cspo/cluster.yaml
@@ -11,7 +11,7 @@ spec:
       cidrBlocks: ["192.168.0.0/16"]
     serviceDomain: "cluster.local"
   topology:
-    class: openstack-ferrol-1-27-v1
+    class: openstack-scs-1-27-v2
     controlPlane:
       metadata: {}
       replicas: 1

--- a/config/cspo/clusterstack.yaml
+++ b/config/cspo/clusterstack.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: cluster
 spec:
   provider: openstack
-  name: ferrol
+  name: scs
   kubernetesVersion: "1.27"
   channel: stable
   autoSubscribe: false
@@ -14,4 +14,4 @@ spec:
     kind: OpenStackClusterStackReleaseTemplate
     name: cspotemplate
   versions:
-    - v1
+    - v2


### PR DESCRIPTION
The tag for which we were fetching is now synced with openstack scs cluster-stack via this commit. 
We use ferrol with docker and scs with openstack ones. 

- Also updated to v2 release 