### PR TITLE
:seedling: Create GitHub client only if it is necessary

### DIFF
--- a/internal/controller/openstackclusterstackrelease_controller.go
+++ b/internal/controller/openstackclusterstackrelease_controller.go
@@ -123,12 +123,6 @@ func (r *OpenStackClusterStackReleaseReconciler) Reconcile(ctx context.Context, 
 	if download {
 		conditions.MarkFalse(openstackclusterstackrelease, apiv1alpha1.ClusterStackReleaseAssetsReadyCondition, apiv1alpha1.ReleaseAssetsNotDownloadedYetReason, clusterv1beta1.ConditionSeverityInfo, "assets not downloaded yet")
 
-		// this is the point where we download the release from github
-		// acquire lock so that only one reconcile loop can download the release
-		r.openStackClusterStackRelDownloadDirectoryMutex.Lock()
-
-		defer r.openStackClusterStackRelDownloadDirectoryMutex.Unlock()
-
 		gc, err := r.GitHubClientFactory.NewClient(ctx)
 		if err != nil {
 			conditions.MarkFalse(openstackclusterstackrelease,
@@ -143,6 +137,12 @@ func (r *OpenStackClusterStackReleaseReconciler) Reconcile(ctx context.Context, 
 		}
 
 		conditions.MarkTrue(openstackclusterstackrelease, apiv1alpha1.GitAPIAvailableCondition)
+
+		// this is the point where we download the release from github
+		// acquire lock so that only one reconcile loop can download the release
+		r.openStackClusterStackRelDownloadDirectoryMutex.Lock()
+
+		defer r.openStackClusterStackRelDownloadDirectoryMutex.Unlock()
 
 		if err := downloadReleaseAssets(ctx, releaseTag, releaseAssets.LocalDownloadPath, gc); err != nil {
 			logger.Error(err, "failed to download release assets")

--- a/internal/controller/openstackclusterstackrelease_controller.go
+++ b/internal/controller/openstackclusterstackrelease_controller.go
@@ -127,6 +127,8 @@ func (r *OpenStackClusterStackReleaseReconciler) Reconcile(ctx context.Context, 
 		// acquire lock so that only one reconcile loop can download the release
 		r.openStackClusterStackRelDownloadDirectoryMutex.Lock()
 
+		defer r.openStackClusterStackRelDownloadDirectoryMutex.Unlock()
+
 		gc, err := r.GitHubClientFactory.NewClient(ctx)
 		if err != nil {
 			conditions.MarkFalse(openstackclusterstackrelease,
@@ -146,8 +148,6 @@ func (r *OpenStackClusterStackReleaseReconciler) Reconcile(ctx context.Context, 
 			logger.Error(err, "failed to download release assets")
 			return ctrl.Result{RequeueAfter: 1 * time.Minute}, nil
 		}
-
-		r.openStackClusterStackRelDownloadDirectoryMutex.Unlock()
 
 		record.Eventf(openstackclusterstackrelease, "ClusterStackReleaseAssetsReady", "successfully downloaded ClusterStackReleaseAssets %q", releaseTag)
 		// requeue to make sure release assets can be accessed


### PR DESCRIPTION
**What this PR does / why we need it**:

create github client only if required, based on SovereignCloudStack/cluster-stack-operator#67, and SovereignCloudStack/cluster-stack-operator#70

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #80

**Special notes for your reviewer**:

_Please confirm that if this PR changes any image versions, then that's the sole change this PR makes._

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

