### PR TITLE
:seedling: Remove unnecessary env variables in make target env-vars-for-wl-cluster

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,14 +1,11 @@
 export KUBECONFIG=$PWD/.mgt-cluster-kubeconfig.yaml
-export GIT_PROVIDER_B64=Z2l0aHVi
-export GIT_ACCESS_TOKEN_B64=mybase64encodedtoken
-export GIT_ORG_NAME_B64=U292ZXJlaWduQ2xvdWRTdGFjaw==
-export GIT_REPOSITORY_NAME_B64=Y2x1c3Rlci1zdGFja3M=
-export EXP_CLUSTER_RESOURCE_SET=true
-export EXP_MACHINE_POOL=true
 export CLUSTER_TOPOLOGY=true
-export EXP_RUNTIME_SDK=true
-export EXP_MACHINE_SET_PREFLIGHT_CHECKS=true
 export CLUSTER_NAME=test-dfkhje
 export SECRET_NAME=supersecret
 export CLOUD_NAME=test
 export ENCODED_CLOUDS_YAML=mybase64encodedcloudsyamlfile
+## These env variables are not needed when local_mode is enabled
+# export GIT_PROVIDER_B64=Z2l0aHVi
+# export GIT_ACCESS_TOKEN_B64=mybase64encodedtoken
+# export GIT_ORG_NAME_B64=U292ZXJlaWduQ2xvdWRTdGFjaw==
+# export GIT_REPOSITORY_NAME_B64=Y2x1c3Rlci1zdGFja3M=

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,7 @@ all-tools: $(GOTESTSUM) $(go-cover-treemap) $(go-binsize-treemap) $(KIND) $(PACK
 ##@ Development
 
 env-vars-for-wl-cluster:
-	@./hack/ensure-env-variables.sh GIT_PROVIDER_B64 GIT_ACCESS_TOKEN_B64 GIT_ORG_NAME_B64 GIT_REPOSITORY_NAME_B64 EXP_CLUSTER_RESOURCE_SET CLUSTER_TOPOLOGY CLUSTER_NAME SECRET_NAME CLOUD_NAME ENCODED_CLOUDS_YAML
+	@./hack/ensure-env-variables.sh CLUSTER_TOPOLOGY CLUSTER_NAME SECRET_NAME CLOUD_NAME ENCODED_CLOUDS_YAML
 
 .PHONY: cluster
 cluster: $(CTLPTL) $(KUBECTL) ## Creates kind-dev Cluster 
@@ -589,4 +589,4 @@ get-kubeconfig-workload-cluster:
 
 .PHONY: tilt-up
 tilt-up: env-vars-for-wl-cluster $(ENVSUBST) $(KUBECTL) $(KUSTOMIZE) $(TILT) cluster  ## Start a mgt-cluster & Tilt. Installs the CRDs and deploys the controllers
-	EXP_CLUSTER_RESOURCE_SET=true $(TILT) up --port=10351
+	$(TILT) up --port=10351

--- a/Makefile
+++ b/Makefile
@@ -160,7 +160,13 @@ all-tools: $(GOTESTSUM) $(go-cover-treemap) $(go-binsize-treemap) $(KIND) $(PACK
 ##@ Development
 
 env-vars-for-wl-cluster:
+ifeq ($(wildcard tilt-settings.yaml),)
+	@./hack/ensure-env-variables.sh GIT_PROVIDER_B64 GIT_ACCESS_TOKEN_B64 GIT_ORG_NAME_B64 GIT_REPOSITORY_NAME_B64 CLUSTER_TOPOLOGY CLUSTER_NAME SECRET_NAME CLOUD_NAME ENCODED_CLOUDS_YAML
+else ifeq ($(shell awk '/local_mode:/ {print tolower($$2)}' tilt-settings.yaml),true)
 	@./hack/ensure-env-variables.sh CLUSTER_TOPOLOGY CLUSTER_NAME SECRET_NAME CLOUD_NAME ENCODED_CLOUDS_YAML
+else
+	@./hack/ensure-env-variables.sh GIT_PROVIDER_B64 GIT_ACCESS_TOKEN_B64 GIT_ORG_NAME_B64 GIT_REPOSITORY_NAME_B64 CLUSTER_TOPOLOGY CLUSTER_NAME SECRET_NAME CLOUD_NAME ENCODED_CLOUDS_YAML	
+endif
 
 .PHONY: cluster
 cluster: $(CTLPTL) $(KUBECTL) ## Creates kind-dev Cluster 


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on the introduction of `local_mode` feature(see issue #76). Some env variables are not needed when we are using local_mode. This commit adjust .envrc.sample and also remove these unnecessary env variables in make target env-vars-for-wl-cluster.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #100 

**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

