### PR TITLE
✨ use new builder image approach

### DIFF
--- a/.envrc.sample
+++ b/.envrc.sample
@@ -1,3 +1,4 @@
+export PATH="$(pwd)/hack/tools/bin/:$PATH"
 export KUBECONFIG=$PWD/.mgt-cluster-kubeconfig.yaml
 export CLUSTER_TOPOLOGY=true
 export CLUSTER_NAME=test-dfkhje

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -122,10 +122,16 @@ jobs:
   release:
     name: Create draft release
     runs-on: ubuntu-latest
+    permissions:
+      packages: read
+    defaults:
+      run:
+        shell: bash
     needs:
       - manager-image
     steps:
       - name: Set env
+        shell: bash
         run: echo "RELEASE_TAG=${GITHUB_REF:10}" >> $GITHUB_ENV
 
       - name: checkout code

--- a/hack/kind-dev.sh
+++ b/hack/kind-dev.sh
@@ -18,7 +18,7 @@ set -o errexit
 set -o pipefail
 set -x
 
-K8S_VERSION=v1.27.2
+K8S_VERSION=v1.27.3
 
 REPO_ROOT=$(git rev-parse --show-toplevel)
 cd "${REPO_ROOT}" || exit 1

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -34,7 +34,7 @@ ARG KUBECTL_VERSION="v1.27.3"
 # update: datasource=github-tags depName=kubernetes-sigs/kustomize extractVersion=^kustomize\/v(?<version>.+)$
 ARG KUSTOMIZE_VERSION="v5.3.0"
 # update: datasource=github-tags depName=aquasecurity/trivy
-ARG TRIVY_VERSION="v0.48.3"
+ARG TRIVY_VERSION="v0.49.1"
 # update: datasource=github-tags depName=kubernetes-sigs/controller-tools
 ARG CONTROLLER_GEN_VERSION="v0.14.0"
 

--- a/images/builder/Dockerfile
+++ b/images/builder/Dockerfile
@@ -1,4 +1,4 @@
-# Copyright 2023 The Kubernetes Authors.
+# Copyright 2024 The Kubernetes Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -17,43 +17,47 @@
 # If you make changes to this Dockerfile run `make builder-image-push`.
 
 # Install Lychee
-FROM docker.io/library/alpine:3.19.1@sha256:6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0 as lychee
-# update: datasource=github-tags depName=lycheeverse/lychee versioning=semver
-ENV LYCHEE_VERSION="v0.14.3"
-# hadolint ignore=DL3018
-RUN apk add --no-cache curl && \
-    curl -L -o /tmp/lychee-${LYCHEE_VERSION}.tgz https://github.com/lycheeverse/lychee/releases/download/${LYCHEE_VERSION}/lychee-${LYCHEE_VERSION}-x86_64-unknown-linux-gnu.tar.gz && \
-    tar -xz -C /tmp -f /tmp/lychee-${LYCHEE_VERSION}.tgz && \
-    mv /tmp/lychee /usr/bin/lychee && \
-    rm -rf /tmp/linux-amd64 /tmp/lychee-${LYCHEE_VERSION}.tgz
-
-# Install Golang CI Lint
-FROM docker.io/library/alpine:3.19.1@sha256:6457d53fb065d6f250e1504b9bc42d5b6c65941d57532c072d929dd0628977d0 as golangci
-# update: datasource=github-tags depName=golangci/golangci-lint versioning=semver
-ENV GOLANGCI_VERSION="v1.56.2"
-WORKDIR /
-# hadolint ignore=DL3018,DL4006
-RUN apk add --no-cache curl && \
-    curl -L -o /tmp/golangci.tgz https://github.com/golangci/golangci-lint/releases/download/${GOLANGCI_VERSION}/golangci-lint-${GOLANGCI_VERSION#v}-linux-amd64.tar.gz && \
-    ls -la /tmp && \
-    tar -xz -C /tmp -f /tmp/golangci.tgz && \
-    mv /tmp/golangci-lint-${GOLANGCI_VERSION#v}-linux-amd64/golangci-lint /bin/golangci-lint
-
+FROM docker.io/lycheeverse/lychee:0.14.3 as lychee
 # Install Hadolint
 FROM docker.io/hadolint/hadolint:v2.12.0-alpine@sha256:7dba9a9f1a0350f6d021fb2f6f88900998a4fb0aaf8e4330aa8c38544f04db42 as hadolint
 
-# Install Trivy
-FROM docker.io/aquasec/trivy:0.49.1@sha256:026a1ab5714dd19ffde0aed18ac034d1d354f119d6e62330cd6522081dd74628 as trivy
+FROM cgr.dev/chainguard/wolfi-base:latest as wolfi
+
+# update: datasource=github-tags depName=kubernetes-sigs/cluster-api
+ARG CLUSTERCTL_VERSION="v1.6.3"
+# update: datasource=github-tags depName=golangci/golangci-lint
+ENV GOLANGCI_VERSION="v1.56.2"
+# update: datasource=github-tags depName=kubernetes-sigs/kind
+ARG KIND_VERSION="v0.22.0"
+# update: datasource=github-tags depName=kubernetes/kubernetes
+ARG KUBECTL_VERSION="v1.27.3"
+# update: datasource=github-tags depName=kubernetes-sigs/kustomize extractVersion=^kustomize\/v(?<version>.+)$
+ARG KUSTOMIZE_VERSION="v5.3.0"
+# update: datasource=github-tags depName=aquasecurity/trivy
+ARG TRIVY_VERSION="v0.48.3"
+# update: datasource=github-tags depName=kubernetes-sigs/controller-tools
+ARG CONTROLLER_GEN_VERSION="v0.14.0"
+
+# hadolint ignore=DL3018
+RUN apk add -U --no-cache \
+    curl \
+    clusterctl=~${CLUSTERCTL_VERSION#v} \
+    controller-gen=~${CONTROLLER_GEN_VERSION#v} \
+    kind=~${KIND_VERSION#v} \
+    kubectl=~${KUBECTL_VERSION#v} \
+    kustomize=~${KUSTOMIZE_VERSION#v} \
+    trivy=~${TRIVY_VERSION#v} 
+
+WORKDIR /
+RUN curl -sfL https://raw.githubusercontent.com/golangci/golangci-lint/master/install.sh | sh -s ${GOLANGCI_VERSION}
 
 ############################
-# Cspo Build Image Base #
+# CSPO Build Image Base #
 ############################
-FROM docker.io/library/golang:1.21.6-bullseye@sha256:a8712f27d9ac742e7bded8f81f7547c5635e855e8b80302e8fc0ce424f559295
+FROM docker.io/library/golang:1.21.8-bullseye
 
 # update: datasource=github-tags depName=adrienverge/yamllint versioning=semver
 ENV YAMLLINT_VERSION="v1.35.1"
-# update: datasource=github-tags depName=opt-nc/yamlfixer versioning=semver
-ENV YAMLFIXER_VERSION="0.9.15"
 
 # hadolint ignore=DL3008
 RUN apt-get update && \
@@ -64,13 +68,17 @@ RUN apt-get update && \
     libsystemd-dev jq && \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* && \
     pip install --no-cache-dir \
-    yamllint==${YAMLLINT_VERSION} \
-    yamlfixer-opt-nc==${YAMLFIXER_VERSION}
+    yamllint==${YAMLLINT_VERSION}
 
-COPY --from=lychee /usr/bin/lychee /usr/bin/lychee
-COPY --from=golangci /bin/golangci-lint /usr/local/bin
+COPY --from=wolfi /usr/bin/clusterctl /usr/bin/clusterctl
+COPY --from=wolfi /usr/bin/controller-gen /usr/bin/controller-gen
+COPY --from=wolfi /bin/golangci-lint /usr/bin/golangci-lint
+COPY --from=wolfi /usr/bin/kubectl /usr/bin/kubectl
+COPY --from=wolfi /usr/bin/kind /usr/bin/kind
+COPY --from=wolfi /usr/bin/kustomize /usr/bin/kustomize
+COPY --from=wolfi /usr/bin/trivy /usr/bin/trivy
+COPY --from=lychee /usr/local/bin/lychee /usr/bin/lychee
 COPY --from=hadolint /bin/hadolint /usr/bin/hadolint
-COPY --from=trivy /usr/local/bin/trivy /usr/bin/trivy
 
 ENV GOCACHE=/go/cache
 

--- a/images/cspo/Dockerfile
+++ b/images/cspo/Dockerfile
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 # Build the manager binary
-FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.21.6-bullseye as build
+FROM --platform=${BUILDPLATFORM} docker.io/library/golang:1.21.8-bullseye as build
 ARG TARGETOS TARGETARCH
 
 COPY . /src/cluster-stack-provider-openstack


### PR DESCRIPTION
Fixes https://github.com/SovereignCloudStack/cluster-stack-provider-openstack/issues/128

this commit updates builder images and adds a make target so that we copy the static executables right from the container image. it's fast and we don't have to pull it from the internet again and again if we have the builder image present locally.

- for testing 

```bash
$ docker build -t ghcr.io/sovereigncloudstack/cspo-builder:0.1.0 -f images/builder/Dockerfile images/builder/
```

And then invoke any of the following make targets because these targets depend on the builder image.

```bash
make lint-yaml
make lint-yaml-ci
make lint-links
make lint-dockerfile
make lint-golang
make lint-golang-ci
make format-golang
make generate-modules
```

Here's the output from my machine: 

<details><summary>Details</summary>
<p>

```bash
$ make lint-yaml
make lint-yaml-ci                                                                                          make lint-links                                                                                             make lint-dockerfile
make lint-golang
make lint-golang-ci
make format-golang
make generate-modules


docker run  --rm -t -i \
        -v /root/go/pkg:/go/pkg \
        -v /root/cluster-stack-provider-openstack:/src/cluster-stack-provider-openstack \
        ghcr.io/sovereigncloudstack/cspo-builder:0.1.0 lint-yaml;
make: Entering directory '/src/cluster-stack-provider-openstack'
yamllint --version
yamllint 1.35.1
yamllint -c .yamllint.yaml --strict .
make: Leaving directory '/src/cluster-stack-provider-openstack'
docker run  --rm -t -i \
        -v /root/go/pkg:/go/pkg \
        -v /root/cluster-stack-provider-openstack:/src/cluster-stack-provider-openstack \
        ghcr.io/sovereigncloudstack/cspo-builder:0.1.0 lint-yaml-ci;
make: Entering directory '/src/cluster-stack-provider-openstack'
yamllint --version
yamllint 1.35.1
yamllint -c .yamllint.yaml . --format github
make: Leaving directory '/src/cluster-stack-provider-openstack'
docker run --rm -t -i \
        -v /root/cluster-stack-provider-openstack:/src/cluster-stack-provider-openstack \
        ghcr.io/sovereigncloudstack/cspo-builder:0.1.0 lint-links;
make: Entering directory '/src/cluster-stack-provider-openstack'
lychee --config .lychee.toml ./*.md  ./docs/**/*.md
  34/34 ━━━━━━━━━━━━━━━━━━━━ Finished extracting links
make: Leaving directory '/src/cluster-stack-provider-openstack'
docker run  --rm -t -i \
        -v /root/go/pkg:/go/pkg \
        -v /root/cluster-stack-provider-openstack:/src/cluster-stack-provider-openstack \
        ghcr.io/sovereigncloudstack/cspo-builder:0.1.0 lint-dockerfile;
make: Entering directory '/src/cluster-stack-provider-openstack'
hadolint --version
Haskell Dockerfile Linter 2.12.0
hadolint -t error ./images/cache/Dockerfile ./images/builder/Dockerfile ./images/cspo/Dockerfile
[{"code":"DL3007","column":1,"file":"./images/builder/Dockerfile","level":"warning","line":24,"message":"Using latest is prone to errors if the image will ever
docker run  --rm -t -i \
        -v /root/go/pkg:/go/pkg \
        -v /root/cluster-stack-provider-openstack:/src/cluster-stack-provider-openstack \
        ghcr.io/sovereigncloudstack/cspo-builder:0.1.0 lint-golang;
make: Entering directory '/src/cluster-stack-provider-openstack'
go version
go version go1.21.8 linux/amd64
golangci-lint version
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a0 on 2024-02-15T18:01:51Z
golangci-lint run -v
INFO [config_reader] Config search paths: [./ /src/cluster-stack-provider-openstack /src /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 47 linters: [asasalint asciicheck bidichk bodyclose containedctx contextcheck durationcheck errchkjson errname errorlint exhaustive expo
INFO [loader] Go packages loading at mode 575 (files|name|deps|exports_file|types_sizes|compiled_files|imports) took 19.166665856s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 6.264492ms
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 12, after processing: 0
INFO [runner] Processors filtering stat (out/in): skip_files: 12/12, filename_unadjuster: 12/12, path_prettifier: 12/12, skip_dirs: 12/12, nolint: 0/9, cgo: 12/
INFO [runner] processing took 2.596524ms with stages: nolint: 1.386458ms, identifier_marker: 694.72µs, autogenerated_exclude: 225.582µs, path_prettifier: 149.95
INFO [runner] linters took 545.870908ms with stages: goanalysis_metalinter: 543.154823ms
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 199 samples, avg is 28.6MB, max is 100.1MB
INFO Execution took 19.724938345s
make: Leaving directory '/src/cluster-stack-provider-openstack'
docker run  --rm -t -i \
        -v /root/go/pkg:/go/pkg \
        -v /root/cluster-stack-provider-openstack:/src/cluster-stack-provider-openstack \
        ghcr.io/sovereigncloudstack/cspo-builder:0.1.0 lint-golang-ci;
make: Entering directory '/src/cluster-stack-provider-openstack'
go version
go version go1.21.8 linux/amd64
golangci-lint version
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a0 on 2024-02-15T18:01:51Z
golangci-lint run -v --out-format=github-actions
INFO [config_reader] Config search paths: [./ /src/cluster-stack-provider-openstack /src /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 47 linters: [asasalint asciicheck bidichk bodyclose containedctx contextcheck durationcheck errchkjson errname errorlint exhaustive expo
INFO [loader] Go packages loading at mode 575 (types_sizes|compiled_files|exports_file|imports|deps|files|name) took 19.280973388s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 6.054439ms
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner] Issues before processing: 12, after processing: 0
INFO [runner] Processors filtering stat (out/in): path_prettifier: 12/12, skip_dirs: 12/12, nolint: 0/9, identifier_marker: 12/12, cgo: 12/12, filename_unadjust
INFO [runner] processing took 2.499632ms with stages: nolint: 1.464439ms, identifier_marker: 604.978µs, autogenerated_exclude: 188.612µs, path_prettifier: 117.2
INFO [runner] linters took 531.53592ms with stages: goanalysis_metalinter: 528.934117ms
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 200 samples, avg is 28.1MB, max is 96.1MB
INFO Execution took 19.824791139s
make: Leaving directory '/src/cluster-stack-provider-openstack'
docker run  --rm -t -i \
        -v /root/go/pkg:/go/pkg \
        -v /root/cluster-stack-provider-openstack:/src/cluster-stack-provider-openstack \
        ghcr.io/sovereigncloudstack/cspo-builder:0.1.0 format-golang;
make: Entering directory '/src/cluster-stack-provider-openstack'
go version
go version go1.21.8 linux/amd64
golangci-lint version
golangci-lint has version 1.56.2 built with go1.22.0 from 58a724a0 on 2024-02-15T18:01:51Z
golangci-lint run -v --fix
INFO [config_reader] Config search paths: [./ /src/cluster-stack-provider-openstack /src /]
INFO [config_reader] Used config file .golangci.yml
INFO [lintersdb] Active 47 linters: [asasalint asciicheck bidichk bodyclose containedctx contextcheck durationcheck errchkjson errname errorlint exhaustive exportloopref forcetypeassert gci gocritic godot gofmt gofumpt goprintffuncname gosec gosimple govet importas ineffassign loggercheck makezero misspell nakedret nilerr noctx nolintlint nosprintfhostport prealloc predeclared reassign revive rowserrcheck staticcheck stylecheck tagliatelle thelper tparallel unconvert unused usestdlibvars wastedassign wrapcheck]
INFO [loader] Go packages loading at mode 575 (compiled_files|imports|name|types_sizes|deps|exports_file|files) took 19.231407223s
INFO [runner/filename_unadjuster] Pre-built 0 adjustments in 4.857484ms
INFO [linters_context/goanalysis] analyzers took 0s with no stages
INFO [runner] fixer took 0s with no stages
INFO [runner] Issues before processing: 12, after processing: 0
INFO [runner] Processors filtering stat (out/in): identifier_marker: 12/12, filename_unadjuster: 12/12, skip_dirs: 12/12, skip_files: 12/12, autogenerated_exclude: 12/12, exclude: 12/12, nolint: 0/9, cgo: 12/12, path_prettifier: 12/12, exclude-rules: 9/12
INFO [runner] processing took 1.983836ms with stages: nolint: 1.123755ms, identifier_marker: 451.256µs, autogenerated_exclude: 169.042µs, path_prettifier: 100.982µs, skip_dirs: 95.911µs, cgo: 19.37µs, fixer: 13.66µs, exclude-rules: 6.07µs, filename_unadjuster: 1.72µs, max_same_issues: 400ns, sort_results: 270ns, skip_files: 230ns, exclude: 230ns, severity-rules: 200ns, uniq_by_line: 160ns, max_from_linter: 120ns, source_code: 110ns, diff: 90ns, max_per_file_from_linter: 90ns, path_shortener: 90ns, path_prefixer: 80ns
INFO [runner] linters took 575.996901ms with stages: goanalysis_metalinter: 573.925284ms
INFO File cache stats: 0 entries of total size 0B
INFO Memory: 200 samples, avg is 28.8MB, max is 92.1MB
INFO Execution took 19.817485395s
make: Leaving directory '/src/cluster-stack-provider-openstack'
docker run  --rm -t -i \
        -v /root/go/pkg:/go/pkg \
        -v /root/cluster-stack-provider-openstack:/src/cluster-stack-provider-openstack \
        ghcr.io/sovereigncloudstack/cspo-builder:0.1.0 generate-modules;
make: Entering directory '/src/cluster-stack-provider-openstack'
./hack/golang-modules-update.sh
all modules verified
make: Leaving directory '/src/cluster-stack-provider-openstack'
$ echo $status
0
```

</p>
</details> 