### PR TITLE
🐛 Fix 403 error in release job

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -123,6 +123,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       packages: read
+      contents: write
     defaults:
       run:
         shell: bash


### PR DESCRIPTION
**What this PR does / why we need it**:
Fixes GitHub error 403 undefined in release job, see https://github.com/SovereignCloudStack/cluster-stack-provider-openstack/actions/runs/8464068433/job/23188344741

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #137 


