### PR TITLE
:sparkles: Support specifying the CA cert or adding verify=false into clouds.yaml

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -4,7 +4,7 @@ This guide explains general info on how to debug issues if a cluster creation fa
 
 ## providerClient authentication err
 
-If you are using https, and when you encounter issue like:
+If you are using https, and when you encounter issues like:
 
 ```
 kubectl logs -n cspoo-system logs -l control-plane=capo-controller-manager <cspo-controller-manager-pod>

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,7 +7,7 @@ This guide explains general info on how to debug issues if a cluster creation fa
 If you are using https, and when you encounter issues like:
 
 ```
-kubectl logs -n cspoo-system logs -l control-plane=capo-controller-manager <cspo-controller-manager-pod>
+kubectl logs -n cspo-system -l control-plane=controller-manager
 ...
 [manager] 2024-04-15T15:20:07Z	DEBUG	events	Post "https://10.0.3.15/identity/v3/auth/tokens": tls: failed to verify certificate: x509: certificate signed by unknown authority	{"type": "Warning", "object": {"kind":"OpenStackNodeImageRelease","namespace":"cluster","name":"openstack-ferrol-1-27-ubuntu-capi-image-v1.27.8-v2","uid":"93d2c1c8-5a19-45f8-9f93-8e8bd5227ebf","apiVersion":"infrastructure.clusterstack.x-k8s.io/v1alpha1","resourceVersion":"3773"}, "reason": "OpenStackProviderClientNotSet"}
 ...

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,29 @@
+# Troubleshooting
+
+This guide explains general info on how to debug issues if a cluster creation fails.
+
+## providerClient authentication err
+
+If you are using https, and when you encounter issue like:
+
+```
+kubectl logs -n cspoo-system logs -l control-plane=capo-controller-manager <cspo-controller-manager-pod>
+...
+[manager] 2024-04-15T15:20:07Z	DEBUG	events	Post "https://10.0.3.15/identity/v3/auth/tokens": tls: failed to verify certificate: x509: certificate signed by unknown authority	{"type": "Warning", "object": {"kind":"OpenStackNodeImageRelease","namespace":"cluster","name":"openstack-ferrol-1-27-ubuntu-capi-image-v1.27.8-v2","uid":"93d2c1c8-5a19-45f8-9f93-8e8bd5227ebf","apiVersion":"infrastructure.clusterstack.x-k8s.io/v1alpha1","resourceVersion":"3773"}, "reason": "OpenStackProviderClientNotSet"}
+...
+```
+
+ you must specify the CA certificate in your secret, which contains the access data to the OpenStack intance, then secret should looks similiar to this example:
+
+ ```bash
+apiVersion: v1
+data:
+  caCert: <PEM_ENCODED_CA_CERT>
+  clouds.yaml: <ENCODED_CLOUDS_YAML>
+kind: Secret
+metadata:
+  labels:
+    clusterctl.cluster.x-k8s.io/move: "true"
+  name: "openstack"
+  namespace: cluster
+ ```

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -18,7 +18,7 @@ you must specify the CA certificate in your secret, which contains the access da
  ```bash
 apiVersion: v1
 data:
-  caCert: <PEM_ENCODED_CA_CERT>
+  cacert: <PEM_ENCODED_CA_CERT>
   clouds.yaml: <ENCODED_CLOUDS_YAML>
 kind: Secret
 metadata:

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -13,7 +13,7 @@ kubectl logs -n cspoo-system logs -l control-plane=capo-controller-manager <cspo
 ...
 ```
 
- you must specify the CA certificate in your secret, which contains the access data to the OpenStack intance, then secret should looks similiar to this example:
+you must specify the CA certificate in your secret, which contains the access data to the OpenStack instance, then secret should look similar to this example:
 
  ```bash
 apiVersion: v1


### PR DESCRIPTION
**What this PR does / why we need it**:
Based on the discussion in matrix chat, see [here](https://matrix.to/#/!NZpJdPGjAHISXnHUil:matrix.org/$b2FJrT-ApeHmVFPXbWZm3ZbK5JoGlNYYIyNwUhM_vXA?via=matrix.org&via=regio.chat&via=matrix.kptt.net). We would like to support a scenario where AuthURL in clouds.yaml is not signed by the public authority like e.g. Let's Encrypt. This can be resolved by specify the CA certificate or adding verify: false into your clouds.yaml file. CAPO already implemented [here](https://github.com/kubernetes-sigs/cluster-api-provider-openstack/blob/acc680d3659da119475ca47530f6cc67f30b524d/docs/book/src/topics/troubleshooting.md#providerclient-authentication-err).

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #146 


**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

