### PR TITLE
🌱 add buildx in renovate workflow

### DIFF
--- a/.github/workflows/schedule-update-bot.yaml
+++ b/.github/workflows/schedule-update-bot.yaml
@@ -32,6 +32,11 @@ jobs:
       - name: Checkout
         uses: actions/checkout@44c2b7a8a4ea60a981eaca3cf939b5f4305c123b # v4.1.5
 
+      # qemu is not required as of now because we don't build images for arm64
+      # use docker/setup-qemu-action@v3 if you want to have arm64 images.
+      - name: Set up Docker Buildx # required for building image
+        uses: docker/setup-buildx-action@d70bba72b1f3fd22344832f00baa16ece964efeb # v3
+
       - name: Generate Token
         uses: actions/create-github-app-token@a0de6af83968303c8c955486bf9739a57d23c7f1 # v1
         id: generate-token


### PR DESCRIPTION
    add buildx in renovate workflow

    renovate workflow failed because we build image in that workflow and
    buildx was missing. buildx is now the default builder of docker and we
    cannot build images without that.
    This commit adds buildx to the renovate workflow so that when renovate
    workflow is run and inside the workflow, if we build docker image then
    that shouldn't give us any error.


--- 
Ref: https://github.com/SovereignCloudStack/cluster-stack-provider-openstack/pull/161#issuecomment-2109927399