### PR TITLE
:bug: Fix image properties propagation

### DIFF
--- a/api/v1alpha1/openstacknodeimagerelease_types.go
+++ b/api/v1alpha1/openstacknodeimagerelease_types.go
@@ -42,7 +42,57 @@ type OpenStackNodeImage struct {
 }
 
 // CreateOpts represents options used to create an image.
-type CreateOpts images.CreateOpts
+// TODO: Reimplement logic to import `images.CreateOpts` from Gophercloud with a `Properties` override.
+// The current `images.CreateOpts` defines `json:"-"` for the `Properties` field, making it unsuitable
+// for proper unmarshalling required for `CreateOpts` used in Kubernetes resources
+// and `nodeimagerelease.yaml`.
+// One solution is to create a new struct specifically for unmarshalling
+// that embeds `images.CreateOpts` and redefines the `Properties` field to allow proper handling.
+type CreateOpts struct {
+	// Name is the name of the new image.
+	Name string `json:"name" required:"true"`
+
+	// Id is the the image ID.
+	ID string `json:"id,omitempty"`
+
+	// Visibility defines who can see/use the image.
+	Visibility *images.ImageVisibility `json:"visibility,omitempty"`
+
+	// Hidden is whether the image is listed in default image list or not.
+	//nolint:tagliatelle // Allow snake_case JSON tags
+	Hidden *bool `json:"os_hidden,omitempty"`
+
+	// Tags is a set of image tags.
+	Tags []string `json:"tags,omitempty"`
+
+	// ContainerFormat is the format of the
+	// container. Valid values are ami, ari, aki, bare, and ovf.
+	//nolint:tagliatelle // Allow snake_case JSON tags
+	ContainerFormat string `json:"container_format,omitempty"`
+
+	// DiskFormat is the format of the disk. If set,
+	// valid values are ami, ari, aki, vhd, vmdk, raw, qcow2, vdi,
+	// and iso.
+	//nolint:tagliatelle // Allow snake_case JSON tags
+	DiskFormat string `json:"disk_format,omitempty"`
+
+	// MinDisk is the amount of disk space in
+	// GB that is required to boot the image.
+	//nolint:tagliatelle // Allow snake_case JSON tags
+	MinDisk int `json:"min_disk,omitempty"`
+
+	// MinRAM is the amount of RAM in MB that
+	// is required to boot the image.
+	//nolint:tagliatelle // Allow snake_case JSON tags
+	MinRAM int `json:"min_ram,omitempty"`
+
+	// protected is whether the image is not deletable.
+	Protected *bool `json:"protected,omitempty"`
+
+	// properties is a set of properties, if any, that
+	// are associated with the image.
+	Properties map[string]string `json:"properties,omitempty"`
+}
 
 // OpenStackNodeImageReleaseStatus defines the observed state of OpenStackNodeImageRelease.
 type OpenStackNodeImageReleaseStatus struct {

--- a/config/crd/bases/infrastructure.clusterstack.x-k8s.io_openstacknodeimagereleases.yaml
+++ b/config/crd/bases/infrastructure.clusterstack.x-k8s.io_openstacknodeimagereleases.yaml
@@ -114,6 +114,13 @@ spec:
                         description: Hidden is whether the image is listed in default
                           image list or not.
                         type: boolean
+                      properties:
+                        additionalProperties:
+                          type: string
+                        description: |-
+                          properties is a set of properties, if any, that
+                          are associated with the image.
+                        type: object
                       protected:
                         description: protected is whether the image is not deletable.
                         type: boolean

--- a/internal/controller/openstacknodeimagerelease_controller_test.go
+++ b/internal/controller/openstacknodeimagerelease_controller_test.go
@@ -421,7 +421,9 @@ func HandleImageCreationSuccessfully(t *testing.T) { //nolint: gocritic
 			"id": "test_id",
 			"name": "test_image",
 			"disk_format": "qcow2",
-			"container_format": "bare"
+			"container_format": "bare",
+			"architecture": "x86_64",
+			"hw_disk_bus": "scsi"
 		}`)
 
 		w.Header().Add("Content-Type", "application/json")
@@ -433,7 +435,9 @@ func HandleImageCreationSuccessfully(t *testing.T) { //nolint: gocritic
 			"disk_format": "qcow2",
 			"visibility": "shared",
 			"min_disk": 0,
-			"id": "test_id"
+			"id": "test_id",
+			"architecture": "x86_64",
+			"hw_disk_bus": "scsi"
 		}`)
 	})
 }
@@ -449,6 +453,7 @@ func TestCreateImage(t *testing.T) {
 		Name:            "test_image",
 		DiskFormat:      "qcow2",
 		ContainerFormat: "bare",
+		Properties:      map[string]string{"architecture": "x86_64", "hw_disk_bus": "scsi"},
 	}
 
 	fakeClient := fakeclient.ServiceClient()
@@ -462,7 +467,7 @@ func TestCreateImage(t *testing.T) {
 		ContainerFormat: "bare",
 		DiskFormat:      "qcow2",
 		Visibility:      "shared",
-		Properties:      map[string]interface{}{},
+		Properties:      map[string]any{"architecture": "x86_64", "hw_disk_bus": "scsi"},
 	}
 
 	assert.NoError(t, err)


### PR DESCRIPTION
<!-- If this is your first PR, welcome! Please make sure you read the [contributing guidelines](../CONTRIBUTING.md#contributing-a-patch). -->
<!-- please add an icon to the title of this PR and delete this line and similar ones -->
<!-- the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patches and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) -->

**What this PR does / why we need it**:

This PR contains a hot-fix that allows CreateOpts.properties definition via `node-images.yaml` as follows:
```yaml
apiVersion: openstack.infrastructure.clusterstack.x-k8s.io/v1alpha1
openStackNodeImages:
  - createOpts:
      container_format: bare
      disk_format: qcow2
      name: ubuntu-capi-image-v1.29.9
      visibility: private
      properties:
        hw_disk_bus: "scsi"
        hw_rng_model: "virtio"
        hw_scsi_model: "virtio-scsi"
    url: ...
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #223 

**Special notes for your reviewer**:





**TODOs**:

- [ ] squash commits
- [ ] include documentation
- [ ] add unit tests

